### PR TITLE
fix: point main to bundled output

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "files": [
         "dist/"
     ],
-    "main": "./src/index.ts",
+    "main": "./dist/mangodoc.min.js",
     "scripts": {
         "start": "webpack-dev-server --mode=development --config ./build/webpack.config.js",
         "build": "webpack --mode=production --config ./build/webpack.config.js"


### PR DESCRIPTION
## Problem

The published `mangodoc` package includes only `dist/`, but `package.json` declares:

```json
"main": "./src/index.ts"
```

For example, `mangodoc@2.14.3` includes `dist/mangodoc.min.js` but no `src/index.ts` in the npm tarball.

## Fix

Point `main` at the bundled file that is actually published: `./dist/mangodoc.min.js`.

## Validation

- Checked `mangodoc@2.14.3` npm tarball: `package/dist/mangodoc.min.js` exists and `package/src/index.ts` is missing
- Verified this branch already contains `dist/mangodoc.min.js`
- `git diff --check`